### PR TITLE
Small "bug" fix that annoyed me.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-recipe-view",
-	"version": "0.3.5",
+	"version": "0.3.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-recipe-view",
-			"version": "0.3.5",
+			"version": "0.3.7",
 			"license": "MIT",
 			"dependencies": {
 				"fraction.js": "^4.3.6"

--- a/src/RecipeCard.svelte
+++ b/src/RecipeCard.svelte
@@ -156,7 +156,7 @@
 				{frontmatter}
 				thumbnailPath={parsedRecipe?.thumbnailPath}
 				singleColumn={true}
-				app={plugin.app}
+				app={plugin}
 				{file}
 				{view}
 			/>
@@ -178,7 +178,7 @@
 				{frontmatter}
 				thumbnailPath={parsedRecipe?.thumbnailPath}
 				singleColumn={false}
-				app={plugin.app}
+				app={plugin}
 				{file}
 				{view}
 			/>
@@ -197,7 +197,7 @@
 				{frontmatter}
 				thumbnailPath={parsedRecipe?.thumbnailPath}
 				singleColumn={false}
-				app={plugin.app}
+				app={plugin}
 				{file}
 				{view}
 			/>

--- a/src/RecipeCardTitleBlock.svelte
+++ b/src/RecipeCardTitleBlock.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
-	import { App, MarkdownRenderer, TFile } from "obsidian";
+	import { App, ColorComponent, MarkdownRenderer, TFile } from "obsidian";
 	import { RecipeView } from "./recipe-view";
+	import { plugin } from "./store";
+	import { mainModule } from "process";
+	import RecipeViewPlugin from "./main";
 
 	export let thumbnailPath: string | undefined;
 	export let title: string;
 	export let frontmatter: object;
 	export let singleColumn: boolean;
-	export let app: App;
+	export let app: RecipeViewPlugin;
 	export let file: TFile;
 	export let view: RecipeView;
 
@@ -39,13 +42,17 @@
 		}
 
 		if (typeof value === "string" || value instanceof String) {
+			if (app.settings.hiddenTags.contains(key)) {
+				return undefined;
+			}
+
 			const markdownContainer = createSpan();
 			MarkdownRenderer.render(
-				app,
+				app.app,
 				value.toString(),
 				markdownContainer,
 				file.path,
-				view
+				view,
 			);
 			// Will just return what's in the first paragraph, so only really works with
 			// a single line – but imo that's fine
@@ -65,7 +72,7 @@
 		/>
 	{/if}
 	<div class="metadata">
-		<div class="inline-title">{title}</div>
+		<h1 class="h1">{title}</h1>
 		<div class="frontmatter">
 			{#if frontmatter}
 				{#each Object.entries(frontmatter) as [key, value]}

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ interface RecipeViewPluginSettings {
 	renderUnicodeFractions: boolean;
 	singleColumnMaxWidth: number;
 	showBulletsTwoColumn: boolean;
+	hiddenTags: Array<string>;
 }
 
 const DEFAULT_SETTINGS: RecipeViewPluginSettings = {
@@ -18,6 +19,7 @@ const DEFAULT_SETTINGS: RecipeViewPluginSettings = {
 	renderUnicodeFractions: true,
 	singleColumnMaxWidth: 600,
 	showBulletsTwoColumn: false,
+	hiddenTags: [],
 }
 
 export default class RecipeViewPlugin extends Plugin {
@@ -148,6 +150,16 @@ class RecipeViewSettingsTab extends PluginSettingTab {
 					this.plugin.settings!.renderUnicodeFractions = value;
 					await this.plugin.saveSettings();
 				}));
+
+		new Setting(containerEl)
+		.setName("Hidden Tags")
+		.setDesc("Tags that will be hidden from the recipe card.")
+		.addTextArea(text => text
+			.setValue(this.plugin.settings!.hiddenTags.join("\n"))
+			.onChange(async (value) => {
+			this.plugin.settings!.hiddenTags = value.split("\n");
+			await this.plugin.saveSettings();
+		}));
 
 		new Setting(containerEl)
 			.setName('Display ingredients in two-column view with bullets')


### PR DESCRIPTION
Bump version to 0.3.7 and add hidden properties setting to Recipe Viewer Title Card and mate title always display even with the hide inline title option active (it just looked bad with it on since it was not made for it)