### PR TITLE
Add support for all property types to recipe view

### DIFF
--- a/src/RecipeCardTitleBlock.svelte
+++ b/src/RecipeCardTitleBlock.svelte
@@ -38,7 +38,7 @@
 				.join(" ");
 		}
 
-		if (typeof value === "string" || value instanceof String) {
+		if (value !== null) {
 			const markdownContainer = createSpan();
 			MarkdownRenderer.render(
 				app,


### PR DESCRIPTION
I believe this closes https://github.com/lachsh/obsidian-recipe-view/issues/15

Currently, this plugin only supports tags and strings property types.
This adds support for the rest of the property types: checkbox, number, list, date, and date & time. It excludes properties with empty values.

It's not very pretty for boolean and datetime types, using the property value's `toString()` method to render the value, but it's better than not rendering the value.


I think a better implementation would be to render the properties as a table the same way as the reading view does, but that's probably a larger scope change.