### PR TITLE
Add a setting to override cooking units

### DIFF
--- a/src/CheckableIngredientList.svelte
+++ b/src/CheckableIngredientList.svelte
@@ -38,9 +38,9 @@
 						checked={isChecked(i)}
 						on:change={(e) => changeChecked(i, e)}
 					/>
-					<div class="leaf">
-						<RecipeLeaf childNodesOf={itemAt(i)} asTag="div" />
-					</div>
+					<span class="leaf">
+						<RecipeLeaf childNodesOf={itemAt(i)} asTag="span" />
+					</span>
 				</label>
 			</li>
 		{/each}

--- a/src/CheckableIngredientList.svelte
+++ b/src/CheckableIngredientList.svelte
@@ -29,19 +29,19 @@
 	<ul class:bullets>
 		{#each list.children as _, i}
 			<li>
-				<label>
-					<!-- Persist checkbox state on component re-construction by setting
-				data-checked on the underlying LI element from the rendered markdown.
-				-->
+				<div class="leaf">
+					<label>
+						<!-- Persist checkbox state on component re-construction by setting
+					data-checked on the underlying LI element from the rendered markdown.
+					-->
 					<input
 						type="checkbox"
 						checked={isChecked(i)}
 						on:change={(e) => changeChecked(i, e)}
 					/>
-					<span class="leaf">
 						<RecipeLeaf childNodesOf={itemAt(i)} asTag="span" />
-					</span>
-				</label>
+					</label>
+				</div>
 			</li>
 		{/each}
 	</ul>
@@ -63,12 +63,12 @@
 		position: relative;
 	}
 
-	input[type="checkbox"]:checked ~ .leaf {
+	.leaf:has(input[type="checkbox"]:checked) {
 		color: var(--text-muted);
 		text-decoration: line-through;
 	}
 
-	input[type="checkbox"]:focus ~ .leaf {
+	.leaf:has(input[type="checkbox"]:focus) {
 		color: var(--text-accent-hover);
 	}
 

--- a/src/RecipeCard.svelte
+++ b/src/RecipeCard.svelte
@@ -21,7 +21,7 @@
 	export let view: RecipeView;
 
 	// Recipe scaling - create store here to pass to all children via ctx
-	let scaleNum = 1;
+	let scaleNum = parsedRecipe?.servings || 1;
 	let qtyScale: Fraction;
 	$: parsedRecipe?.qtyScaleStore.set(qtyScale);
 

--- a/src/RecipeLeaf.svelte
+++ b/src/RecipeLeaf.svelte
@@ -25,6 +25,4 @@
 	});
 </script>
 
-<span>
-	<svelte:element this={asTag} bind:this={root} class="recipe-leaf" />
-</span>
+<svelte:element this={asTag} bind:this={root} />

--- a/src/RecipeLeaf.svelte
+++ b/src/RecipeLeaf.svelte
@@ -25,6 +25,6 @@
 	});
 </script>
 
-<div>
+<span>
 	<svelte:element this={asTag} bind:this={root} class="recipe-leaf" />
-</div>
+</span>

--- a/src/SelectableStepList.svelte
+++ b/src/SelectableStepList.svelte
@@ -38,12 +38,10 @@
 	<!-- means steps is an array of P elements -->
 	{#each pList() as p}
 		<div class="leaf">
-			<p>
-				<label>
-					<input type="radio" name={radioName} />
-					<RecipeLeaf childNodesOf={p} asTag="span" />
-				</label>
-			</p>
+			<label>
+				<input type="radio" name={radioName} />
+				<RecipeLeaf childNodesOf={p} asTag="span" />
+			</label>
 		</div>
 	{/each}
 {/if}

--- a/src/SelectableStepList.svelte
+++ b/src/SelectableStepList.svelte
@@ -40,7 +40,7 @@
 		<div class="leaf">
 			<label>
 				<input type="radio" name={radioName} />
-				<RecipeLeaf childNodesOf={p} asTag="span" />
+				<RecipeLeaf childNodesOf={p} asTag="p" />
 			</label>
 		</div>
 	{/each}
@@ -59,6 +59,7 @@
 		margin: 0;
 		padding: 0;
 		z-index: -1;
+		display: none; /* otherwise the p branch above looks broken is Safari */
 	}
 
 	label {

--- a/src/SelectableStepList.svelte
+++ b/src/SelectableStepList.svelte
@@ -41,9 +41,9 @@
 			<p>
 				<label>
 					<input type="radio" name={radioName} />
-					<div class="leaf">
-						<RecipeLeaf childNodesOf={p} asTag="div" />
-					</div>
+					<span class="leaf">
+						<RecipeLeaf childNodesOf={p} asTag="span" />
+					</span>
 				</label>
 			</p>
 		</div>

--- a/src/SelectableStepList.svelte
+++ b/src/SelectableStepList.svelte
@@ -26,9 +26,9 @@
 				<li>
 					<label>
 						<input type="radio" name={radioName} />
-						<div class="leaf">
-							<RecipeLeaf childNodesOf={olChild(i)} asTag="div" />
-						</div>
+						<span class="leaf">
+							<RecipeLeaf childNodesOf={olChild(i)} asTag="span" />
+						</span>
 					</label>
 				</li>
 			{/each}
@@ -42,7 +42,7 @@
 				<label>
 					<input type="radio" name={radioName} />
 					<div class="leaf">
-						<RecipeLeaf childNodesOf={p} asTag="div" />
+						<RecipeLeaf childNodesOf={p} asTag="span" />
 					</div>
 				</label>
 			</p>

--- a/src/SelectableStepList.svelte
+++ b/src/SelectableStepList.svelte
@@ -24,12 +24,12 @@
 		<ol class="recipe-mutex-select">
 			{#each olChildren() as _, i}
 				<li>
-					<label>
-						<input type="radio" name={radioName} />
-						<span class="leaf">
+					<div class="leaf">
+						<label>
+							<input type="radio" name={radioName} />
 							<RecipeLeaf childNodesOf={olChild(i)} asTag="span" />
-						</span>
-					</label>
+						</label>
+					</div>
 				</li>
 			{/each}
 		</ol>
@@ -37,13 +37,11 @@
 {:else if kind == "p"}
 	<!-- means steps is an array of P elements -->
 	{#each pList() as p}
-		<div>
+		<div class="leaf">
 			<p>
 				<label>
 					<input type="radio" name={radioName} />
-					<span class="leaf">
-						<RecipeLeaf childNodesOf={p} asTag="span" />
-					</span>
+					<RecipeLeaf childNodesOf={p} asTag="span" />
 				</label>
 			</p>
 		</div>
@@ -83,7 +81,7 @@
 		margin-inline-start: calc(-1 * var(--list-indent));
 	}
 
-	input[type="radio"]:checked ~ .leaf {
+	.leaf:has(input[type="radio"]:checked) {
 		background-color: hsla(
 			var(--accent-h),
 			var(--accent-s),
@@ -92,7 +90,7 @@
 		);
 	}
 
-	input[type="radio"]:focus ~ .leaf {
+	.leaf:has(input[type="radio"]:focus) {
 		box-shadow: inset 0px 0px 0px var(--border-width)
 			var(--interactive-accent);
 	}

--- a/src/SelectableStepList.svelte
+++ b/src/SelectableStepList.svelte
@@ -42,7 +42,7 @@
 				<label>
 					<input type="radio" name={radioName} />
 					<div class="leaf">
-						<RecipeLeaf childNodesOf={p} asTag="span" />
+						<RecipeLeaf childNodesOf={p} asTag="div" />
 					</div>
 				</label>
 			</p>

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { WHISK_SVG } from './whisk';
 
 interface RecipeViewPluginSettings {
 	sideColumnRegex: string;
+	unitRegex: string;
 	treatH1AsFilename: boolean;
 	renderUnicodeFractions: boolean;
 	singleColumnMaxWidth: number;
@@ -14,6 +15,7 @@ interface RecipeViewPluginSettings {
 
 const DEFAULT_SETTINGS: RecipeViewPluginSettings = {
 	sideColumnRegex: 'Ingredients|Nutrition',
+	unitRegex: 'tb?sp?s?\.?|tablespoons?|teaspoons?|k?g|(kilo)?grams?|cups?|m?Ls?|millilit(re|er)s?|lit(re|er)s?|(fl.?|fluid)?\s+(oz\.?|ounces?)|pounds?|lbs?\.?|sticks?',
 	treatH1AsFilename: false,
 	renderUnicodeFractions: true,
 	singleColumnMaxWidth: 600,
@@ -121,6 +123,17 @@ class RecipeViewSettingsTab extends PluginSettingTab {
 				.setValue(this.plugin.settings!.sideColumnRegex)
 				.onChange(async (value) => {
 					this.plugin.settings!.sideColumnRegex = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
+			.setName('Units regex')
+			.setDesc('A regular expression for units of quantities of ingredients')
+			.addText(text => text
+				.setPlaceholder('tsp|tbsp|g')
+				.setValue(this.plugin.settings!.unitRegex)
+				.onChange(async (value) => {
+					this.plugin.settings!.unitRegex = value;
 					await this.plugin.saveSettings();
 				}));
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { App, Plugin, PluginSettingTab, Setting, WorkspaceLeaf, addIcon } from 'obsidian';
+import { DEFAULT_UNIT } from './quantities';
 
 import { RecipeView, VIEW_TYPE_RECIPE } from './recipe-view';
 import store from './store';
@@ -13,9 +14,9 @@ interface RecipeViewPluginSettings {
 	showBulletsTwoColumn: boolean;
 }
 
-const DEFAULT_SETTINGS: RecipeViewPluginSettings = {
+export const DEFAULT_SETTINGS: RecipeViewPluginSettings = {
 	sideColumnRegex: 'Ingredients|Nutrition',
-	unitRegex: 'tb?sp?s?\.?|tablespoons?|teaspoons?|k?g|(kilo)?grams?|cups?|m?Ls?|millilit(re|er)s?|lit(re|er)s?|(fl.?|fluid)?\s+(oz\.?|ounces?)|pounds?|lbs?\.?|sticks?',
+	unitRegex: DEFAULT_UNIT,
 	treatH1AsFilename: false,
 	renderUnicodeFractions: true,
 	singleColumnMaxWidth: 600,

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -25,6 +25,7 @@ export interface ParsedRecipeSection {
 export interface ParsedRecipe {
     title: string;
     thumbnailPath: string;
+    servings: number;
     sections: Array<ParsedRecipeSection>;
     renderedMarkdownParent: HTMLElement;
     qtyScaleStore: Writable<Fraction>;
@@ -121,6 +122,7 @@ export function parseRecipeMarkdown(
     const result: ParsedRecipe = {
         title: "",
         thumbnailPath: "",
+        servings: 1,
         sections: [{
             containsHeader: false,
             sideComponents: [],
@@ -189,6 +191,16 @@ export function parseRecipeMarkdown(
         // get rid of the display: none frontmatter
         if (item.matches("pre.frontmatter")) {
             continue;
+        }
+
+        // Detect **Servings**: N and extract the number
+        if (item.nodeName == "P") {
+            const text = item.textContent || "";
+            const servingsMatch = text.match(/^\s*\*?\*?Servings\*?\*?\s*:\s*(\d+)\s*$/);
+            if (servingsMatch) {
+                result.servings = parseInt(servingsMatch[1]);
+                continue;
+            }
         }
 
         // Extract the first image as a thumbnail

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -30,7 +30,7 @@ export interface ParsedRecipe {
     qtyScaleStore: Writable<Fraction>;
 }
 
-function parseForQty(n: Node, qtyScaleStore: Writable<Fraction>) {
+function parseForQty(plugin: RecipeViewPlugin, n: Node, qtyScaleStore: Writable<Fraction>) {
     if (n.nodeType == Node.ELEMENT_NODE) {
         if (
             (n as HTMLElement).hasAttribute("data-qty") ||
@@ -44,7 +44,7 @@ function parseForQty(n: Node, qtyScaleStore: Writable<Fraction>) {
         const parent = n.parentNode!;
         let currentIndex = 0;
         n.textContent = n.textContent!.normalize("NFKD").replaceAll("\u2044", "/");
-        for (const match of matchQuantities(n.textContent!)) {
+        for (const match of matchQuantities(n.textContent!, plugin.settings.unitRegex)) {
             parent.insertBefore(
                 document.createTextNode(
                     n.textContent!.slice(currentIndex, match.index)
@@ -74,33 +74,33 @@ function parseForQty(n: Node, qtyScaleStore: Writable<Fraction>) {
 
     if (n.hasChildNodes()) {
         Array.from(n.childNodes).forEach((c) =>
-            parseForQty(c, qtyScaleStore)
+            parseForQty(plugin, c, qtyScaleStore)
         );
     }
 }
 
-function injectQuantities(parsedRecipe: ParsedRecipe) {
+function injectQuantities(plugin: RecipeViewPlugin, parsedRecipe: ParsedRecipe) {
     parsedRecipe.sections.flatMap((s) => s.sideComponents.concat(s.mainComponents)).map((c) => {
         switch (c.type) {
             case RecipeLeaf:
                 Array.from((c.props.childNodesOf as HTMLElement).querySelectorAll("[data-qty-parse]"))
-                    .forEach((n) => parseForQty(n, parsedRecipe.qtyScaleStore));
+                    .forEach((n) => parseForQty(plugin, n, parsedRecipe.qtyScaleStore));
                 break;
 
             case SelectableStepList:
                 if (c.props.kind == "ol") {
                     Array.from((c.props.list as HTMLElement).querySelectorAll("[data-qty-parse]"))
-                        .forEach((n) => parseForQty(n, parsedRecipe.qtyScaleStore));
+                        .forEach((n) => parseForQty(plugin, n, parsedRecipe.qtyScaleStore));
                 } else {
                     (c.props.list as Array<HTMLElement>).forEach((p) => {
                         Array.from(p.querySelectorAll("[data-qty-parse]"))
-                            .forEach((n) => parseForQty(n, parsedRecipe.qtyScaleStore));
+                            .forEach((n) => parseForQty(plugin, n, parsedRecipe.qtyScaleStore));
                     })
                 }
                 break;
 
             case CheckableIngredientList:
-                parseForQty((c.props.list as HTMLElement), parsedRecipe.qtyScaleStore);
+                parseForQty(plugin, (c.props.list as HTMLElement), parsedRecipe.qtyScaleStore);
                 break;
 
             default:
@@ -282,7 +282,7 @@ export function parseRecipeMarkdown(
         });
     }
 
-    injectQuantities(result);
+    injectQuantities(plugin, result);
 
     return result;
 }

--- a/src/quantities.test.ts
+++ b/src/quantities.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 import Fraction from "fraction.js";
-import { reUnicodeFractions, matchQuantities, QtyFormatType, formatQuantity } from './quantities'
+import { reUnicodeFractions, matchQuantities, QtyFormatType, formatQuantity, DEFAULT_UNIT } from './quantities'
 
 describe('re-unicoding fractions', () => {
     test('converts a lone fraction', () => {
@@ -22,9 +22,11 @@ describe('re-unicoding fractions', () => {
     });
 });
 
+const defaultUnitRegex = DEFAULT_UNIT;
+
 describe('matching single quantities in strings', () => {
     test('matches a decimal number', () => {
-        expect(matchQuantities("2.67"))
+        expect(matchQuantities("2.67", defaultUnitRegex))
             .toStrictEqual([{
                 index: 0,
                 length: 4,
@@ -33,7 +35,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches a fraction', () => {
-        expect(matchQuantities("3/4"))
+        expect(matchQuantities("3/4", defaultUnitRegex))
             .toStrictEqual([{
                 index: 0,
                 length: 3,
@@ -42,7 +44,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches integer with unit', () => {
-        expect(matchQuantities("xxx 200g"))
+        expect(matchQuantities("xxx 200g", defaultUnitRegex))
             .toStrictEqual([{
                 index: 4,
                 length: 4,
@@ -51,7 +53,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('unit at start is retained', () => {
-        expect(matchQuantities("200g of flour"))
+        expect(matchQuantities("200g of flour", defaultUnitRegex))
             .toStrictEqual([{
                 index: 0,
                 length: 4,
@@ -60,7 +62,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches integer at start', () => {
-        expect(matchQuantities("12 eggs"))
+        expect(matchQuantities("12 eggs", defaultUnitRegex))
             .toStrictEqual([{
                 index: 0,
                 length: 2,
@@ -69,7 +71,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches ASCII fraction with unit', () => {
-        expect(matchQuantities("xxx 1/2 cup"))
+        expect(matchQuantities("xxx 1/2 cup", defaultUnitRegex))
             .toStrictEqual([{
                 index: 4,
                 length: 7,
@@ -78,7 +80,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches ASCII fraction at start', () => {
-        expect(matchQuantities("3/16 sprig"))
+        expect(matchQuantities("3/16 sprig", defaultUnitRegex))
             .toStrictEqual([{
                 index: 0,
                 length: 4,
@@ -87,7 +89,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches normalised Unicode fraction with unit', () => {
-        expect(matchQuantities("xxx \u00BD lb".normalize("NFKD").replace("\u2044", "/")))
+        expect(matchQuantities("xxx \u00BD lb".normalize("NFKD").replace("\u2044", "/"), defaultUnitRegex))
             .toStrictEqual([{
                 index: 4,
                 length: 6,
@@ -96,7 +98,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches normalised Unicode fraction at start', () => {
-        expect(matchQuantities("\u2075\u2044\u2086 bunch".normalize("NFKD").replace("\u2044", "/")))
+        expect(matchQuantities("\u2075\u2044\u2086 bunch".normalize("NFKD").replace("\u2044", "/"), defaultUnitRegex))
             .toStrictEqual([{
                 index: 0,
                 length: 3,
@@ -105,7 +107,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches decimal with unit', () => {
-        expect(matchQuantities("xxx 3.5L"))
+        expect(matchQuantities("xxx 3.5L", defaultUnitRegex))
             .toStrictEqual([{
                 index: 4,
                 length: 4,
@@ -114,7 +116,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches decimal at start', () => {
-        expect(matchQuantities("1.92 something"))
+        expect(matchQuantities("1.92 something", defaultUnitRegex))
             .toStrictEqual([{
                 index: 0,
                 length: 4,
@@ -123,7 +125,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches mixed ASCII number with space with unit', () => {
-        expect(matchQuantities("xxx 2 3/4 tablespoons"))
+        expect(matchQuantities("xxx 2 3/4 tablespoons", defaultUnitRegex))
             .toStrictEqual([{
                 index: 4,
                 length: 17,
@@ -132,7 +134,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches mixed ASCII number with space at start', () => {
-        expect(matchQuantities("10 3/8 unitless"))
+        expect(matchQuantities("10 3/8 unitless", defaultUnitRegex))
             .toStrictEqual([{
                 index: 0,
                 length: 6,
@@ -141,7 +143,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches mixed ASCII number with dash with unit', () => {
-        expect(matchQuantities("xxx 2-3/4 tablespoons"))
+        expect(matchQuantities("xxx 2-3/4 tablespoons", defaultUnitRegex))
             .toStrictEqual([{
                 index: 4,
                 length: 17,
@@ -150,7 +152,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches mixed ASCII number with dash at start', () => {
-        expect(matchQuantities("10-3/8 unitless"))
+        expect(matchQuantities("10-3/8 unitless", defaultUnitRegex))
             .toStrictEqual([{
                 index: 0,
                 length: 6,
@@ -159,7 +161,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches mixed Unicode number with space with unit', () => {
-        expect(matchQuantities("xxx 2 \u00BE tablespoons".normalize("NFKD").replace("\u2044", "/")))
+        expect(matchQuantities("xxx 2 \u00BE tablespoons".normalize("NFKD").replace("\u2044", "/"), defaultUnitRegex))
             .toStrictEqual([{
                 index: 4,
                 length: 17,
@@ -168,7 +170,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches mixed Unicode number with space at start', () => {
-        expect(matchQuantities("10 \u215C unitless".normalize("NFKD").replace("\u2044", "/")))
+        expect(matchQuantities("10 \u215C unitless".normalize("NFKD").replace("\u2044", "/"), defaultUnitRegex))
             .toStrictEqual([{
                 index: 0,
                 length: 6,
@@ -177,7 +179,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches mixed Unicode number with dash with unit', () => {
-        expect(matchQuantities("xxx 2-\u00BE tablespoons".normalize("NFKD").replace("\u2044", "/")))
+        expect(matchQuantities("xxx 2-\u00BE tablespoons".normalize("NFKD").replace("\u2044", "/"), defaultUnitRegex))
             .toStrictEqual([{
                 index: 4,
                 length: 17,
@@ -186,7 +188,7 @@ describe('matching single quantities in strings', () => {
             }]);
     });
     test('matches mixed Unicode number with dash at start', () => {
-        expect(matchQuantities("10-\u215C unitless".normalize("NFKD").replace("\u2044", "/")))
+        expect(matchQuantities("10-\u215C unitless".normalize("NFKD").replace("\u2044", "/"), defaultUnitRegex))
             .toStrictEqual([{
                 index: 0,
                 length: 6,
@@ -199,7 +201,7 @@ describe('matching single quantities in strings', () => {
 describe('matching multiple quantities in strings', () => {
     test('decimal and fraction together', () => {
         // https://github.com/lachholden/obsidian-recipe-view/issues/20
-        expect(matchQuantities("1.5 g (¼ tsp) vanilla paste".normalize("NFKD").replace("\u2044", "/")))
+        expect(matchQuantities("1.5 g (¼ tsp) vanilla paste".normalize("NFKD").replace("\u2044", "/"), defaultUnitRegex))
             .toStrictEqual([
                 {
                     index: 0,

--- a/src/quantities.test.ts
+++ b/src/quantities.test.ts
@@ -52,6 +52,15 @@ describe('matching single quantities in strings', () => {
                 unit: "g",
             }]);
     });
+    test('matches integer with unit, using custom regex', () => {
+        expect(matchQuantities("цукини 200г", 'г'))
+            .toStrictEqual([{
+                index: 7,
+                length: 4,
+                value: { value: new Fraction(200, 1), format: QtyFormatType.DECIMAL },
+                unit: "г",
+            }]);
+    });
     test('unit at start is retained', () => {
         expect(matchQuantities("200g of flour", defaultUnitRegex))
             .toStrictEqual([{

--- a/src/quantities.ts
+++ b/src/quantities.ts
@@ -2,12 +2,6 @@ import Fraction from "fraction.js";
 
 export const DEFAULT_UNIT = 'tb?sp?s?\.?|tablespoons?|teaspoons?|k?g|(kilo)?grams?|cups?|m?Ls?|millilit(re|er)s?|lit(re|er)s?|(fl.?|fluid)?\s+(oz\.?|ounces?)|pounds?|lbs?\.?|sticks?';
 
-/** Matches numbers of the forms e.g. 1, 1.5, 1/2, 3 1/2, 5-3/4 */
-export const NUMBER = new RegExp(/\d+(([\s-]+\d+)?\/\d+|\.\d+)?/)
-
-/** Matches a number at the start of a string by itself */
-export const START_NUMBER_ALONE = new RegExp("(?<startnumber>^" + NUMBER.source + ")\\b", "ig");
-
 export enum QtyFormatType {
     FRACTION,
     DECIMAL,
@@ -72,8 +66,10 @@ function quantityStringsToValue(str: string, unit?: string) {
  * NFKD normalisation + replacing \u2044 with a slash.
  */
 export function matchQuantities(str: string, unitRegex: string) {
+	const NUMBER = new RegExp(/\d+(([\s-]+\d+)?\/\d+|\.\d+)?/)
     const UNIT = new RegExp(unitRegex, "i");
     const NUMBER_WITH_UNIT = new RegExp("(?<number>" + NUMBER.source + ")\\s*(?<unit>" + UNIT.source + ")\\b", "ig");
+	const START_NUMBER_ALONE = new RegExp("(?<startnumber>^" + NUMBER.source + ")\\b", "ig");
     const QUANTITY = new RegExp(NUMBER_WITH_UNIT.source + "|" + START_NUMBER_ALONE.source, "ig");
 
     return Array.from(str.matchAll(QUANTITY)).map((match) => {

--- a/src/quantities.ts
+++ b/src/quantities.ts
@@ -3,17 +3,8 @@ import Fraction from "fraction.js";
 /** Matches numbers of the forms e.g. 1, 1.5, 1/2, 3 1/2, 5-3/4 */
 export const NUMBER = new RegExp(/\d+(([\s-]+\d+)?\/\d+|\.\d+)?/)
 
-/** Matches a whole bunch of common units that you would want to scale in recipes */
-export const UNIT = new RegExp(/tb?sp?s?\.?|tablespoons?|teaspoons?|k?g|(kilo)?grams?|cups?|m?Ls?|millilit(re|er)s?|lit(re|er)s?|(fl.?|fluid)?\s+(oz\.?|ounces?)|pounds?|lbs?\.?|sticks?/i)
-
-/** Matches a number followed by some whitespace and a unit */
-export const NUMBER_WITH_UNIT = new RegExp("(?<number>" + NUMBER.source + ")\\s*(?<unit>" + UNIT.source + ")\\b", "ig");
-
 /** Matches a number at the start of a string by itself */
 export const START_NUMBER_ALONE = new RegExp("(?<startnumber>^" + NUMBER.source + ")\\b", "ig");
-
-/** Matches either a number at the start of a string, or otherwise a number and unit */
-export const QUANTITY = new RegExp(NUMBER_WITH_UNIT.source + "|" + START_NUMBER_ALONE.source, "ig");
 
 export enum QtyFormatType {
     FRACTION,
@@ -78,7 +69,11 @@ function quantityStringsToValue(str: string, unit?: string) {
  * Requires unicode fractions to have already been normalised to ASCII, which involves
  * NFKD normalisation + replacing \u2044 with a slash.
  */
-export function matchQuantities(str: string) {
+export function matchQuantities(str: string, unitRegex: string) {
+    const UNIT = new RegExp(unitRegex, "i");
+    const NUMBER_WITH_UNIT = new RegExp("(?<number>" + NUMBER.source + ")\\s*(?<unit>" + UNIT.source + ")\\b", "ig");
+    const QUANTITY = new RegExp(NUMBER_WITH_UNIT.source + "|" + START_NUMBER_ALONE.source, "ig");
+
     return Array.from(str.matchAll(QUANTITY)).map((match) => {
         return {
             index: match.index,

--- a/src/quantities.ts
+++ b/src/quantities.ts
@@ -68,9 +68,9 @@ function quantityStringsToValue(str: string, unit?: string) {
 export function matchQuantities(str: string, unitRegex: string) {
 	const NUMBER = new RegExp(/\d+(([\s-]+\d+)?\/\d+|\.\d+)?/)
     const UNIT = new RegExp(unitRegex, "i");
-    const NUMBER_WITH_UNIT = new RegExp("(?<number>" + NUMBER.source + ")\\s*(?<unit>" + UNIT.source + ")\\b", "ig");
+    const NUMBER_WITH_UNIT = new RegExp("(?<number>" + NUMBER.source + ")\\s*(?<unit>" + UNIT.source + ")(?!\\p{L})", "igu");
 	const START_NUMBER_ALONE = new RegExp("(?<startnumber>^" + NUMBER.source + ")\\b", "ig");
-    const QUANTITY = new RegExp(NUMBER_WITH_UNIT.source + "|" + START_NUMBER_ALONE.source, "ig");
+    const QUANTITY = new RegExp(NUMBER_WITH_UNIT.source + "|" + START_NUMBER_ALONE.source, "igu");
 
     return Array.from(str.matchAll(QUANTITY)).map((match) => {
         return {

--- a/src/quantities.ts
+++ b/src/quantities.ts
@@ -1,5 +1,7 @@
 import Fraction from "fraction.js";
 
+export const DEFAULT_UNIT = 'tb?sp?s?\.?|tablespoons?|teaspoons?|k?g|(kilo)?grams?|cups?|m?Ls?|millilit(re|er)s?|lit(re|er)s?|(fl.?|fluid)?\s+(oz\.?|ounces?)|pounds?|lbs?\.?|sticks?';
+
 /** Matches numbers of the forms e.g. 1, 1.5, 1/2, 3 1/2, 5-3/4 */
 export const NUMBER = new RegExp(/\d+(([\s-]+\d+)?\/\d+|\.\d+)?/)
 

--- a/src/quantities.ts
+++ b/src/quantities.ts
@@ -1,6 +1,6 @@
 import Fraction from "fraction.js";
 
-export const DEFAULT_UNIT = 'tb?sp?s?\.?|tablespoons?|teaspoons?|k?g|(kilo)?grams?|cups?|m?Ls?|millilit(re|er)s?|lit(re|er)s?|(fl.?|fluid)?\s+(oz\.?|ounces?)|pounds?|lbs?\.?|sticks?';
+export const DEFAULT_UNIT = "tb?sp?s?\\.?|tablespoons?|teaspoons?|k?g|(kilo)?grams?|cups?|m?Ls?|millilit(re|er)s?|lit(re|er)s?|(fl.?|fluid)?\\s+(oz\\.?|ounces?)|pounds?|lbs?\\.?|sticks?";
 
 export enum QtyFormatType {
     FRACTION,


### PR DESCRIPTION
Hi,

I need https://github.com/lachsh/obsidian-recipe-view/issues/25 to make this -- awesome, by way! -- plugin work with recipes in my language. So here's my crude attempt at implementing it.

1. Adds a "Units regex" setting that overrides `UNIT` regex
2. Adds support for non-ASCII units

Regarding 2, it turns out that `/b` only works with ASCII, even when `u` flag is enabled, so I had to replace it with a negative lookahead (`(?!\p{L})`) in one instance. I also added a test case for `matchQuantities` with a custom non-ASCII regex.

Not happy about passing `plugin` everywhere, but I don't know a better way.