### PR TITLE
quantities: add support for ranges

### DIFF
--- a/src/quantities.test.ts
+++ b/src/quantities.test.ts
@@ -215,6 +215,57 @@ describe('matching multiple quantities in strings', () => {
                 }
             ]);
     });
+    test('simple range', () => {
+        expect(matchQuantities("1-2 eggs"))
+            .toStrictEqual([
+                {
+                    index: 0,
+                    length: 1,
+                    value: { value: new Fraction(1, 1), format: QtyFormatType.FRACTION },
+                    unit: null
+                },
+                {
+                    index: 2,
+                    length: 1,
+                    value: { value: new Fraction(2, 1), format: QtyFormatType.FRACTION },
+                    unit: null
+                }
+            ]);
+    });
+    test('simple range with whitespace', () => {
+        expect(matchQuantities("1 - 2 eggs"))
+            .toStrictEqual([
+                {
+                    index: 0,
+                    length: 1,
+                    value: { value: new Fraction(1, 1), format: QtyFormatType.FRACTION },
+                    unit: null
+                },
+                {
+                    index: 4,
+                    length: 1,
+                    value: { value: new Fraction(2, 1), format: QtyFormatType.FRACTION },
+                    unit: null
+                }
+            ]);
+    });
+    test('simple range with unit', () => {
+        expect(matchQuantities("1-2 tbsp salt"))
+            .toStrictEqual([
+                {
+                    index: 0,
+                    length: 1,
+                    value: { value: new Fraction(1, 1), format: QtyFormatType.FRACTION },
+                    unit: null
+                },
+                {
+                    index: 2,
+                    length: 6,
+                    value: { value: new Fraction(2, 1), format: QtyFormatType.FRACTION },
+                    unit: "tbsp"
+                }
+            ]);
+    });
 });
 
 describe('formatting scaled quantities', () => {

--- a/src/quantities.ts
+++ b/src/quantities.ts
@@ -11,9 +11,10 @@ export const NUMBER_WITH_UNIT = new RegExp("(?<number>" + NUMBER.source + ")\\s*
 
 /** Matches a number at the start of a string by itself */
 export const START_NUMBER_ALONE = new RegExp("(?<startnumber>^" + NUMBER.source + ")\\b", "ig");
+export const RANGE_END_NUMBER   = new RegExp("(?<=" + NUMBER.source + "\\s*-\\s*)(?<endnumber>" + NUMBER.source + ")\\b", "ig");
 
 /** Matches either a number at the start of a string, or otherwise a number and unit */
-export const QUANTITY = new RegExp(NUMBER_WITH_UNIT.source + "|" + START_NUMBER_ALONE.source, "ig");
+export const QUANTITY = new RegExp(NUMBER_WITH_UNIT.source + "|" + START_NUMBER_ALONE.source + "|" + RANGE_END_NUMBER.source, "ig");
 
 export enum QtyFormatType {
     FRACTION,
@@ -83,7 +84,7 @@ export function matchQuantities(str: string) {
         return {
             index: match.index,
             length: match[0].length,
-            value: quantityStringsToValue(match.groups!.number || match.groups!.startnumber, match.groups!.unit),
+            value: quantityStringsToValue(match.groups!.number || match.groups!.startnumber || match.groups!.endnumber, match.groups!.unit),
             unit: match.groups!.unit || null,
         }
     });


### PR DESCRIPTION
Some recipes have ranges like

   1 - 2 eggs
   1-2 tbsp salt

The end number of the range needs to be scaled too.

- add RANGE_END_NUMBER with a look-behind assertion so that the 2nd number of the range is included in the list of quantities
- add match group "endnumber" to the list of values
- add tests for ranges