### PR TITLE
Feat/use image property

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { WHISK_SVG } from './whisk';
 interface RecipeViewPluginSettings {
 	sideColumnRegex: string;
 	treatH1AsFilename: boolean;
+	useImageProperty: boolean;
 	renderUnicodeFractions: boolean;
 	singleColumnMaxWidth: number;
 	showBulletsTwoColumn: boolean;
@@ -133,6 +134,14 @@ class RecipeViewSettingsTab extends PluginSettingTab {
 					this.plugin.settings!.treatH1AsFilename = value;
 					await this.plugin.saveSettings();
 				}));
+
+		new Setting(containerEl)
+			.setName("Use image property")
+			.setDesc('If turned on, then uses the image property for the recipe thumbnail instead.')
+			.addToggle((toggle) => toggle.setValue(this.plugin.settings.useImageProperty).onChange(async (value) => {
+				this.plugin.settings.useImageProperty = value;
+				await this.plugin.saveSettings();
+			}));
 
 		new Setting(containerEl)
 			.setName("Recipe card appearance")

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ interface RecipeViewPluginSettings {
 const DEFAULT_SETTINGS: RecipeViewPluginSettings = {
 	sideColumnRegex: 'Ingredients|Nutrition',
 	treatH1AsFilename: false,
+	useImageProperty: false,
 	renderUnicodeFractions: true,
 	singleColumnMaxWidth: 600,
 	showBulletsTwoColumn: false,

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -193,6 +193,7 @@ export function parseRecipeMarkdown(
 
         // Extract the first image as a thumbnail
         if (
+            !plugin.settings.useImageProperty && 
             item.getElementsByTagName("IMG").length > 0 &&
             currentSection == 0 &&
             !result.thumbnailPath &&

--- a/src/recipe-view.ts
+++ b/src/recipe-view.ts
@@ -72,7 +72,20 @@ export class RecipeView extends EditableFileView {
         const image = frontmatter?.["image"];
         const parsedRecipe = parseRecipeMarkdown(this.plugin, text, this.file!.path, this);
         if (this.plugin.settings.useImageProperty && image) {
-            parsedRecipe.thumbnailPath = image; // Set thumbnail path from frontmatter image property
+            const link = import_obsidian4.LinkValue.parseFromString(this.app, image, this.file.path);
+            if (link) {
+                // wiki link - match only the [[file name]] portion
+                const match = image.match(/^\[\[([^|\]]+?)(?:\|[^#\]]+?)?(?:#[^]]+)?(?:\^[^]]+)?\]\]$/);
+                if (match) {
+                const imageFile = this.app.metadataCache.getFirstLinkpathDest(match[1], this.file.path);
+                    if (imageFile) {
+                        parsedRecipe.thumbnailPath = this.app.vault.getResourcePath(imageFile);
+                    }
+                }
+            } else {
+                // external link
+                parsedRecipe.thumbnailPath = image; // Set thumbnail path from frontmatter image
+            }
         }
         this.content = new RecipeCard({
             target: this.contentEl,

--- a/src/recipe-view.ts
+++ b/src/recipe-view.ts
@@ -68,7 +68,12 @@ export class RecipeView extends EditableFileView {
         if (!this.file) { return false }
         const text = await this.app.vault.cachedRead(this.file!);
         const metadata = await this.app.metadataCache.getFileCache(this.file!);
+        const frontmatter = metadata?.frontmatter;
+        const image = frontmatter?.["image"];
         const parsedRecipe = parseRecipeMarkdown(this.plugin, text, this.file!.path, this);
+        if (this.plugin.settings.useImageProperty && image) {
+            parsedRecipe.thumbnailPath = image; // Set thumbnail path from frontmatter image property
+        }
         this.content = new RecipeCard({
             target: this.contentEl,
             props: {


### PR DESCRIPTION
Adds a Use image property setting with a default of false.
When enabled, reads the image property in the metadata for a wiki link or external link and sets it to the thumbnail path.
Fixes #43 